### PR TITLE
Add support for Firefox, Safari

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 .DS_Store
 package-lock.json
+.vscode/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ const unswitch = new Unswitch({
   x: (pressed) => {},
   l: (pressed) => {},
   r: (pressed) => {},
+  minus: (pressed) => {},
+  plus: (pressed) => {},
+  lstick: (pressed) => {},
+  rstick: (pressed) => {},
+  home: (pressed) => {},
+  screenshot: (pressed) => {},
+  side: (pressed) => {}, // The 'Side' button near ZL or ZR
+  z: (pressed) => {}, // ZL or ZR
   axes: (position) => {},
 });
 

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -18,6 +18,9 @@ const controllerLeft = new Controller({
   x: pressed => logButton('1 ~ X', pressed),
   l: pressed => logButton('1 ~ L', pressed),
   r: pressed => logButton('1 ~ R', pressed),
+  minus: pressed => logButton('1 ~ Minus', pressed),
+  screenshot: pressed => logButton('1 ~ Screenshot', pressed),
+  lstick: pressed => logButton('1 ~ L Stick', pressed),
   axes: position => LogAxes('1', position),
 });
 
@@ -29,6 +32,9 @@ const controllerRight = new Controller({
   x: pressed => logButton('2 ~ X', pressed),
   l: pressed => logButton('2 ~ L', pressed),
   r: pressed => logButton('2 ~ R', pressed),
+  plus: pressed => logButton('2 ~ Plus', pressed),
+  home: pressed => logButton('2 ~ Home', pressed),
+  rstick: pressed => logButton('2 ~ R Stick', pressed),
   axes: position => LogAxes('2', position),
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,34 +1,37 @@
-const m = ['b', 'a', 'y', 'x', 'l', 'r'];
+const buttonMappings = ['b', 'a', 'y', 'x', 'l', 'r'];
 
-function Unswitch(s) {
-  this.a = 8;
-  this.b = {};
-  this.c = {};
-  for (let i = 0; i < m.length; i += 1) {
-    this.b[m[i]] = { p: false };
+function Unswitch(userSettings) {
+  this.axisPosition = 8;
+  this.buttonState = {};
+  this.settings = {};
+  for (let i = 0; i < buttonMappings.length; i += 1) {
+    this.buttonState[buttonMappings[i]] = { pressed: false };
   }
-  Object.assign(this.c, s);
+  Object.assign(this.settings, userSettings);
   this.update = () => {
     const gamepads = navigator.getGamepads();
     for (let i = 0; i < Object.keys(gamepads).length; i += 1) {
-      if (gamepads[i] && gamepads[i].id && gamepads[i].id.indexOf(this.c.side) !== -1) {
-        const pad = gamepads[i];
-        const { buttons, axes } = pad;
-        for (let j = 0; j < m.length; j += 1) {
-          const button = m[j];
-          if (this.b[button].p !== buttons[j].pressed && this.c[button]) {
-            this.b[button].p = buttons[j].pressed;
-            this.c[button](this.b[button].p);
-          }
-        }
-        if (this.c.axes) {
-          const position = Math.round(axes[9] / (2 / 7) + 3.5);
-          if (position !== this.a) {
-            this.c.axes(position);
-            this.a = position;
-          }
-        }
+      if (gamepads[i] && gamepads[i].id && gamepads[i].id.indexOf(this.settings.side) !== -1) {
+        this.updatePad(gamepads[i]);
         break;
+      }
+    }
+  };
+
+  this.updatePad = (pad) => {
+    const { buttons, axes } = pad;
+    for (let j = 0; j < buttonMappings.length; j += 1) {
+      const button = buttonMappings[j];
+      if (this.buttonState[button].pressed !== buttons[j].pressed && this.settings[button]) {
+        this.buttonState[button].pressed = buttons[j].pressed;
+        this.settings[button](this.buttonState[button].pressed);
+      }
+    }
+    if (this.settings.axes) {
+      const position = Math.round(axes[9] / (2 / 7) + 3.5);
+      if (position !== this.axisPosition) {
+        this.settings.axes(position);
+        this.axisPosition = position;
       }
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,24 @@
-const buttonMappings = ['a', 'x', 'b', 'y', 'l', 'r', 'UNUSED', 'UNUSED', 'minus', 'plus', 'lstick', 'rstick', 'home', 'screenshot', 'side', 'z'];
+const buttonMappings = ['a', 'x', 'b', 'y', 'l', 'r', 'UNUSED', 'UNUSED', 'minus', 'plus', 'lstick', 'rstick', 'home', 'screenshot', 'sidetrigger', 'z'];
+const usesChromeAxes = axes => axes.length === 10;
+
+// Used by Firefox, Safari
+const ffAxisPosition = (buttons) => {
+  const [right, left, down, up] = [...buttons].reverse();
+  const buttonValues = [up, right, down, left]
+    .map((pressed, i) => (pressed.value ? (i * 2) : false))
+    .filter(val => val !== false);
+  if (buttonValues.length === 0) {
+    return 8;
+  }
+  if (buttonValues.length === 2 && buttonValues[0] === 0 && buttonValues[1] === 6) {
+    return 7;
+  }
+  const buttonSums = buttonValues.reduce((prev, curr) => prev + curr, 0);
+  return buttonSums / buttonValues.length;
+};
+
+// Used by Chrome
+const chromeAxisPosition = axes => Math.round(axes[9] / (2 / 7) + 3.5);
 
 function Unswitch(userSettings) {
   this.axisPosition = 8;
@@ -28,7 +48,7 @@ function Unswitch(userSettings) {
       }
     }
     if (this.settings.axes) {
-      const position = Math.round(axes[9] / (2 / 7) + 3.5);
+      const position = usesChromeAxes(axes) ? chromeAxisPosition(axes) : ffAxisPosition(buttons);
       if (position !== this.axisPosition) {
         this.settings.axes(position);
         this.axisPosition = position;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const buttonMappings = ['b', 'a', 'y', 'x', 'l', 'r'];
+const buttonMappings = ['a', 'x', 'b', 'y', 'l', 'r', 'UNUSED', 'UNUSED', 'minus', 'plus', 'lstick', 'rstick', 'home', 'screenshot', 'side', 'z'];
 
 function Unswitch(userSettings) {
   this.axisPosition = 8;


### PR DESCRIPTION
Few additional changes beyond fixing the axes on Firefox/Safari:

* Adds support for the other Joy-Con buttons, such as ZL, Plus/Minus, etc
* Remaps A/B/X/Y; I found they weren't aligned

I renamed and moved a bunch of variables around; I hope it wasn't too intrusive 😶 

Fixes #3 

Also FWIW, the Pro Controller has a pretty different setup than the Joy-Cons, and I wasn't ready to tackle that as part of this PR.